### PR TITLE
Make "All changed packages" option first in package list

### DIFF
--- a/.changeset/ab7df9de/changes.json
+++ b/.changeset/ab7df9de/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@changesets/cli", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/ab7df9de/changes.md
+++ b/.changeset/ab7df9de/changes.md
@@ -1,0 +1,1 @@
+Make "All changed packages" option first in package list

--- a/packages/cli/src/commands/add/createChangeset.js
+++ b/packages/cli/src/commands/add/createChangeset.js
@@ -49,7 +49,7 @@ async function getPackagesToRelease(changedPackages, allPackages) {
       .filter(name => !changedPackages.includes(name));
 
     const selectAllPackagesOptions =
-      allPackages.length > 10 ? ["All packages", "All changed packages"] : [];
+      allPackages.length > 10 ? ["All changed packages", "All packages"] : [];
 
     const defaultInquirerList = [
       ...selectAllPackagesOptions,


### PR DESCRIPTION
When I've been creating changesets recently, I've been wanting the "All changed packages" option and basically never the "All packages" option so making it first would be nice because then the workflow is `yarn changeset` -> <kbd>space</kbd> -> <kbd>enter</kbd> instead of  `yarn changeset` -> <kbd>down</kbd> -> <kbd>space</kbd> -> <kbd>enter</kbd> 