### PR TITLE
Convert bolt-replacements/getWorkspaces to TypeScript

### DIFF
--- a/.changeset/104c1606/changes.json
+++ b/.changeset/104c1606/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@changesets/cli", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/104c1606/changes.md
+++ b/.changeset/104c1606/changes.md
@@ -1,0 +1,1 @@
+Convert a file to TypeScript

--- a/.changeset/c760a708/changes.json
+++ b/.changeset/c760a708/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "get-workspaces", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/c760a708/changes.md
+++ b/.changeset/c760a708/changes.md
@@ -1,0 +1,1 @@
+Distribute TypeScript types

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^24.7.1",
     "jest-fixtures": "^0.5.0",
-    "preconstruct": "0.0.0-ts-types-build.1"
+    "preconstruct": "^0.0.70"
   },
   "preconstruct": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^24.7.1",
     "jest-fixtures": "^0.5.0",
-    "preconstruct": "^0.0.64"
+    "preconstruct": "0.0.0-ts-types-build.1"
   },
   "preconstruct": {
     "packages": [

--- a/packages/cli/src/utils/bolt-replacements/getWorkspaces.ts
+++ b/packages/cli/src/utils/bolt-replacements/getWorkspaces.ts
@@ -1,5 +1,5 @@
 import getWorkspaces from "get-workspaces";
 
-export default function(opts) {
+export default function(opts: { cwd: string }) {
   return getWorkspaces({ tools: ["yarn", "bolt", "root"], ...opts });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4057,10 +4057,10 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-preconstruct@0.0.0-ts-types-build.1:
-  version "0.0.0-ts-types-build.1"
-  resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.0-ts-types-build.1.tgz#c772cdec68bd3fc45af8c7dac6329a8614e56b64"
-  integrity sha512-eGYi1kcOzSuJDI578MVlLVCVzVI+cC6u3JjH95LYQA1rAjx/o+PZq22UxGMsgfDJV4a/rFwY6yDS1SwnxyMvlQ==
+preconstruct@^0.0.70:
+  version "0.0.70"
+  resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.70.tgz#4e17c85f7f76e698ca982475223628ed0d09e68b"
+  integrity sha512-Aon5VBbZ/wLfi02N/Lfdh3OSzslvNTThb6NLh2OT0h0NyuU6Y4S52eKGt9/KLrw6X5s1tc56z1tYGGJ2QsFH4A==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,6 +777,17 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
+"@preconstruct/hook@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@preconstruct/hook/-/hook-0.0.1.tgz#79484f9dceabb970319cd03ec1d8eac71ec6eae5"
+  integrity sha512-cpr6LzI0OW1lZxmixkGNqC3KM8XzPFLX7bpj0uClt6sN7wXXc93gHK8YvAO7FqXxmBZKPF6e5KTJJtXISr+InA==
+  dependencies:
+    "@babel/core" "^7.1.2"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    pirates "^4.0.1"
+    source-map-support "^0.5.12"
+
 "@types/babel__core@^7.1.0":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.1.tgz#ce9a9e5d92b7031421e1d0d74ae59f572ba48be6"
@@ -866,9 +877,10 @@
   version "11.13.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
 
-"@types/node@^11.13.9":
-  version "11.13.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.10.tgz#4df59e5966b56f512bac98898bcbee5067411f0f"
+"@types/node@^12.0.2":
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.2.tgz#3452a24edf9fea138b48fad4a0a028a683da1e40"
+  integrity sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -2742,6 +2754,13 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-reference@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.2.tgz#01cf91517d21db66a34642287ed6e70d53dcbe5c"
+  integrity sha512-Kn5g8c7XHKejFOpTf2QN9YjiHHKl5xRj+2uAZf9iM2//nkBNi/NNeB5JMoun28nEaUVHyPUzqzhfRlfAirEjXg==
+  dependencies:
+    "@types/estree" "0.0.39"
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -4038,13 +4057,15 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-preconstruct@^0.0.64:
-  version "0.0.64"
-  resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.64.tgz#15ef861319f6b7bd1ca7c6f129de105222f6df2f"
+preconstruct@0.0.0-ts-types-build.1:
+  version "0.0.0-ts-types-build.1"
+  resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.0-ts-types-build.1.tgz#c772cdec68bd3fc45af8c7dac6329a8614e56b64"
+  integrity sha512-eGYi1kcOzSuJDI578MVlLVCVzVI+cC6u3JjH95LYQA1rAjx/o+PZq22UxGMsgfDJV4a/rFwY6yDS1SwnxyMvlQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.1.2"
     "@babel/plugin-transform-runtime" "^7.2.0"
+    "@preconstruct/hook" "^0.0.1"
     builtin-modules "^3.0.0"
     chalk "^2.3.2"
     dataloader "^1.4.0"
@@ -4063,16 +4084,15 @@ preconstruct@^0.0.64:
     meow "^5.0.0"
     ms "^2.1.1"
     p-limit "^2.0.0"
-    pirates "^4.0.1"
     quick-lru "^4.0.0"
     resolve "^1.10.0"
     resolve-from "^4.0.0"
-    rollup "^1.0.0"
-    rollup-plugin-alias "^1.4.0"
-    rollup-plugin-commonjs "^9.3.4"
-    rollup-plugin-node-resolve "^4.0.0"
-    rollup-plugin-replace "^2.0.0"
-    rollup-pluginutils "^2.6.0"
+    rollup "^1.12.2"
+    rollup-plugin-alias "^1.5.1"
+    rollup-plugin-commonjs "^10.0.0"
+    rollup-plugin-node-resolve "^5.0.0"
+    rollup-plugin-replace "^2.2.0"
+    rollup-pluginutils "^2.7.1"
     sarcastic "^1.5.0"
     terser "^3.14.1"
     xxhash-wasm "^0.3.1"
@@ -4423,33 +4443,39 @@ rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-alias@^1.4.0:
+rollup-plugin-alias@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-alias/-/rollup-plugin-alias-1.5.1.tgz#80cce3a967befda5b09c86abc14a043a78035b46"
+  integrity sha512-pQTYBRNfLedoVOO7AYHNegIavEIp4jKTga5jUi1r//KYgHKGWgG4qJXYhbcWKt2k1FwGlR5wCYoY+IFkme0t4A==
   dependencies:
     slash "^2.0.0"
 
-rollup-plugin-commonjs@^9.3.4:
-  version "9.3.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz#2b3dddbbbded83d45c36ff101cdd29e924fd23bc"
+rollup-plugin-commonjs@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.0.tgz#58901ebe7ca44c2a03f0056de9bf9eb4a2dc8990"
+  integrity sha512-B8MoX5GRpj3kW4+YaFO/di2JsZkBxNjVmZ9LWjUoTAjq8N9wc7HObMXPsrvolVV9JXVtYSscflXM14A19dXPNQ==
   dependencies:
     estree-walker "^0.6.0"
+    is-reference "^1.1.2"
     magic-string "^0.25.2"
-    resolve "^1.10.0"
-    rollup-pluginutils "^2.6.0"
+    resolve "^1.10.1"
+    rollup-pluginutils "^2.7.0"
 
-rollup-plugin-node-resolve@^4.0.0:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.3.tgz#638a373a54287d19fcc088fdd1c6fd8a58e4d90a"
+rollup-plugin-node-resolve@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.0.tgz#754abf4841ed4bab2241551cba0a11d04c57f290"
+  integrity sha512-JUFr7DkFps3div9DYwpSg0O+s8zuSSRASUZUVNx6h6zhw2m8vcpToeS68JDPsFbmisMVSMYK0IxftngCRv7M9Q==
   dependencies:
     "@types/resolve" "0.0.8"
     builtin-modules "^3.1.0"
     is-module "^1.0.0"
-    resolve "^1.10.0"
+    resolve "^1.10.1"
+    rollup-pluginutils "^2.7.0"
 
-rollup-plugin-replace@^2.0.0:
+rollup-plugin-replace@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
+  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
   dependencies:
     magic-string "^0.25.2"
     rollup-pluginutils "^2.6.0"
@@ -4461,12 +4487,21 @@ rollup-pluginutils@^2.6.0:
     estree-walker "^0.6.0"
     micromatch "^3.1.10"
 
-rollup@^1.0.0:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.11.3.tgz#6f436db2a2d6b63f808bf60ad01a177643dedb81"
+rollup-pluginutils@^2.7.0, rollup-pluginutils@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.7.1.tgz#a7915ce8b12c177364784bf38a1590cc6c2c8250"
+  integrity sha512-3nRf3buQGR9qz/IsSzhZAJyoK663kzseps8itkYHr+Z7ESuaffEPfgRinxbCRA0pf0gzLqkNKkSb8aNVTq75NA==
+  dependencies:
+    estree-walker "^0.6.0"
+    micromatch "^3.1.10"
+
+rollup@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.12.2.tgz#a7c34a4bef71feb43e3ae69f0b26ae683e75db44"
+  integrity sha512-ePehZfVMIE4eO0/LV6VaMY8kp0D9sbziUabpBeJbHAHa2WJPxuS0lYLmiLamb02e098RIRyq1F2yjM4O08dQVA==
   dependencies:
     "@types/estree" "0.0.39"
-    "@types/node" "^11.13.9"
+    "@types/node" "^12.0.2"
     acorn "^6.1.1"
 
 rsvp@^4.8.4:
@@ -4669,7 +4704,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@~0.5.10:
+source-map-support@^0.5.12, source-map-support@^0.5.6, source-map-support@~0.5.10:
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
   dependencies:


### PR DESCRIPTION
This converts a single file to TypeScript which is the one that depends on `get-workspaces`, I converted this specific file so that I could test type resolving across packages in a monorepo and what preconstruct needs to do. What I've ended up with is preconstruct creates a symlink from `dist/get-workspaces.cjs.js.ts` to the source file in dev and in prod, it generates a file at `dist/get-workspaces.cjs.js.d.ts` which is just like the flow redirect. (I want to generate actual TS declarations soon but this is a good first step)